### PR TITLE
Issue code not added if already in the commit msg + Handle the case of 2 codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Main advantage would be that it is easy to see what tasks/stories are being rele
 Having this automated is important so we don't waste time filling out this code on every commit message and so we don't get it wrong when switching between branches we are working on.
 
 ## Branch naming convention
+
+### One issue code
+
 Since the story code is taken from the branch name we assume the following convention for the branch naming:
 
 **{type_of_branch}/{story_code}/{name_of_story}**
@@ -28,6 +31,24 @@ we get:
 If you are in the develop branch and you commit the commit message will look like:
 
 **[develop] my commit message**
+
+### Two issue codes
+
+If subtasks are used, the naming convention for branch name can be:
+
+**{type_of_branch}/{story_code}/{subtask_code}/{name_of_subtask}**
+
+for example from branch name:
+
+**subtask/API-34193/API-34194/edit-refund-role-part-one**
+
+we get:
+
+**[API-34193] [API-34194] my commit message**
+
+### No issue codes
+
+If the branch name doesn't contain any code, the commit message won't be modified.
 
 ## Dependencies
 

--- a/prepare-commit-msg.js
+++ b/prepare-commit-msg.js
@@ -83,11 +83,13 @@ function writeContentToCommitMsgFile(newContents) {
 }
 
 function createNewCommitMsg(originalDefaultCommitMsg, taskCode, description) {
-    let newContents = util.format('[%s] %s', taskCode, originalDefaultCommitMsg);
-    if (description) {
-
-        newContents = util.format('%s\n\n%s', newContents, description);
+    if (originalDefaultCommitMsg.indexOf("[" + taskCode + "]") >= 0) {
+        return originalDefaultCommitMsg;
     }
 
+    let newContents = util.format('[%s] %s', taskCode, originalDefaultCommitMsg);
+    if (description) {
+        newContents = util.format('%s\n\n%s', newContents, description);
+    }
     return newContents;
 }

--- a/prepare-commit-msg.js
+++ b/prepare-commit-msg.js
@@ -18,14 +18,14 @@ if (isPathToDefaultCommitMsgBeingPassedAsArg()) {
 
             const originalDefaultCommitMsg = readContentOfDefaultCommitMsg(),
                 branchName = trimExtraCharactersFromStartAndEndOfLine(stdout),
-                taskCode = getTaskCodeFromBranchName(branchName);
+                tasksCode = getTasksCodeFromBranchName(branchName);
 
             exec(createCommandToGetBranchDescription(branchName),
                 (err, stdout, stderr) => {
                     let description = getDescription(stdout);
 
                     if (isInABranch(branchName)) {
-                        let newContents = createNewCommitMsg(originalDefaultCommitMsg, taskCode, description);
+                        let newContents = createNewCommitMsg(originalDefaultCommitMsg, tasksCode, description);
                         writeContentToCommitMsgFile(newContents);
                         process.exit(0);
                     } else {
@@ -63,13 +63,25 @@ function trimExtraCharactersFromStartAndEndOfLine(stdout) {
     return stdout.replace('* ', '').replace('\n', '');
 }
 
-function getTaskCodeFromBranchName(branchName) {
+/**
+ * Return ann array containing 1 or 2 tasks code depending on the format of the branch name.
+ * @param {string} branchName branch name whose format could be:
+ *  - {type_of_branch}/{story_code}/{name_of_story}
+ *  - {type_of_branch}/{story_code}/{subtask_code}/{name_of_subtask}
+ *  - what you want
+ */
+function getTasksCodeFromBranchName(branchName) {
     const branchNameParts = branchName.split('/');
-    if (branchNameParts.length >= 2) {
-        return branchNameParts[1];
+    if (branchNameParts.length == 3) {
+        // Case with only one code (story code)
+        return [branchNameParts[1]];
+    }
+    if (branchNameParts.length > 3) {
+        // Case with 2 codes (story and subtask)
+        return [branchNameParts[1], branchNameParts[2]];
     }
 
-    return '';
+    return [];
 }
 
 function readContentOfDefaultCommitMsg() {
@@ -82,12 +94,34 @@ function writeContentToCommitMsgFile(newContents) {
     fs.writeFileSync(process.argv[2], newContents);
 }
 
-function createNewCommitMsg(originalDefaultCommitMsg, taskCode, description) {
-    if (originalDefaultCommitMsg.indexOf("[" + taskCode + "]") >= 0) {
+/**
+ * If present, prepend to the commit message the task(s) code(s) written in the branch name.
+ * @param {string} originalDefaultCommitMsg the orginal commit message
+ * @param {array} tasksCode an array containing the tasks code written in the branch name
+ * @param {string} description the description in the commit message
+ */
+function createNewCommitMsg(originalDefaultCommitMsg, tasksCode, description) {
+    let newContents;
+    let tasksCodesToPrepend = '';
+    if (tasksCode.length >= 1) {
+        const firstTaskCode = tasksCode[0];
+        if (originalDefaultCommitMsg.indexOf("[" + firstTaskCode + "]") == -1) {
+            tasksCodesToPrepend = util.format('[%s] ', firstTaskCode);
+        }
+        if (tasksCode.length >= 2) {
+            const secondTaskCode = tasksCode[1];
+            if (originalDefaultCommitMsg.indexOf("[" + secondTaskCode + "]") == -1) {
+                tasksCodesToPrepend = util.format('%s[%s] ', tasksCodesToPrepend, secondTaskCode);
+            }
+        }
+    }
+    
+    if (tasksCodesToPrepend == '') {
         return originalDefaultCommitMsg;
     }
 
-    let newContents = util.format('[%s] %s', taskCode, originalDefaultCommitMsg);
+    newContents = util.format('%s%s', tasksCodesToPrepend, originalDefaultCommitMsg);
+
     if (description) {
         newContents = util.format('%s\n\n%s', newContents, description);
     }


### PR DESCRIPTION
Hello,

First of all, thank you for your script, we have been using it for several months 😄 

This PR does 2 things:
1. We encountered an issue by doing rebase: the issue code is added even if it's already written in the commit message. This PR fix this.
2. We use subtasks in Jira and we create a branch per subtask. We want to have the story code AND the subtask code in the branch name and the commit message. So in the PR, 3 branch naming convention are supported (instead of 2):
- `{type_of_branch}/{story_code}/{name_of_story}` => `[{story_code}] {commit msg}`
- **NEW** `{type_of_branch}/{story_code}/{subtask_code}/{name_of_subtask}` => `[{story_code}] [{subtask_code}] {commit msg}`
- anything else => `{commit msg}`